### PR TITLE
Add support for working mipmap chain on iOS (going down to 1x1)

### DIFF
--- a/EtcLib/Etc/Etc.cpp
+++ b/EtcLib/Etc/Etc.cpp
@@ -116,6 +116,14 @@ namespace Etc
 
 			mipWidth >>= 1;
 			mipHeight >>= 1;
+
+			// Get out of the loop if both shifted dimensions are zero
+			if ((mipWidth==0) && (mipHeight==0))
+				break;
+
+			// Make sure to generate mipmap chain down to 1x1 for iOS
+			if (mipWidth==0) mipWidth = 1;
+			if (mipHeight==0) mipHeight = 1;
 		}
 
 		*a_piEncodingTime_ms = totalEncodingTime;

--- a/EtcTool/EtcTool.cpp
+++ b/EtcTool/EtcTool.cpp
@@ -162,7 +162,8 @@ int main(int argc, const char * argv[])
 
 		// Calculate the maximum number of possible mipmaps
 		{
-			int dim = (uiSourceWidth < uiSourceHeight)?uiSourceWidth:uiSourceHeight;
+			// Use maximum dimension to make sure to go down to 1x1 for iOS
+			int dim = (uiSourceWidth > uiSourceHeight)?uiSourceWidth:uiSourceHeight;
 			int maxMips = 0;
 			while(dim >= 1)
 			{


### PR DESCRIPTION
iOS devices require to provide a full mipmap chain down to 1x1 mipmap size.
The current etc2comp code is fine but for square textures only.

This PR adjusts the mipmapping behavior to match the one provided by PVRTexTool on generating lowest mipmap levels on non-square textures.