### PR TITLE
Fix memory leak in EtcFilter

### DIFF
--- a/EtcLib/Etc/EtcFilter.cpp
+++ b/EtcLib/Etc/EtcFilter.cpp
@@ -228,6 +228,7 @@ int FilterTwoPass( RGBCOLOR *pSrcImage, int srcWidth, int srcHeight,
     pTempImage = (RGBCOLOR *)malloc( destWidth * srcHeight * sizeof(RGBCOLOR) );
     if ( pTempImage == NULL )
     {
+        free( contrib );
         return 0;
     }
 


### PR DESCRIPTION
Im one of the contributors to Godot engine and we use this submodule. It would be nice if this will be fixed here