### PR TITLE
Fixed output path problem which did not allow using spaces.

### DIFF
--- a/EtcTool/EtcTool.cpp
+++ b/EtcTool/EtcTool.cpp
@@ -816,7 +816,7 @@ void Commands::PrintUsageMessage(void)
 		char strCommand[300];
 
 #if ETC_WINDOWS
-		sprintf_s(strCommand, "if not exist %s %s %s", path, ETC_MKDIR_COMMAND, path);
+		sprintf_s(strCommand, "if not exist \"%s\" %s \"%s\"", path, ETC_MKDIR_COMMAND, path);
 #else
 		sprintf(strCommand, "%s %s", ETC_MKDIR_COMMAND, path);
 #endif


### PR DESCRIPTION
Current version of etc2comp cannot contain spaces because of the limitation in the given sprintf_s. Fixed the problem by wrapping the paths with quotes.