### PR TITLE
Enable using outside USE_STB_IMAGE_LOAD definition

### DIFF
--- a/EtcLib/Etc/EtcConfig.h
+++ b/EtcLib/Etc/EtcConfig.h
@@ -55,7 +55,9 @@ typedef double	f64;
 
 // 0=disable. stb_image can be used if you need to compress 
 //other image formats like jpg
+#ifndef USE_STB_IMAGE_LOAD
 #define USE_STB_IMAGE_LOAD 0	
+#endif
 
 #if ETC_WINDOWS
 #include <SDKDDKVer.h>


### PR DESCRIPTION
When using etc2comp as a libarary, they may want to control whether use stb_image by writting different build script RATHER THAN changing the source code.
@mainroach 